### PR TITLE
Add ParserColorFormat

### DIFF
--- a/inc/rlottie.h
+++ b/inc/rlottie.h
@@ -306,7 +306,7 @@ public:
     static std::unique_ptr<Animation>
     loadFromData(std::string jsonData, const std::string &key,
                  const std::string &resourcePath="", bool cachePolicy=true,
-	             const std::vector<std::pair<std::uint32_t, std::uint32_t>> &colorReplacements = {},
+                 const std::vector<std::pair<std::uint32_t, std::uint32_t>> &colorReplacements = {},
                  FitzModifier fitzModifier = FitzModifier::None,
                  ParserColorFormat colorFormat = ParserColorFormat::Rgb);
 

--- a/inc/rlottie.h
+++ b/inc/rlottie.h
@@ -52,6 +52,11 @@ enum class FitzModifier {
     Type6
 };
 
+enum ParserColorFormat {
+    Rgb,
+    Bgr
+};
+
 /**
  *  @brief Configures rlottie model cache policy.
  *
@@ -301,8 +306,9 @@ public:
     static std::unique_ptr<Animation>
     loadFromData(std::string jsonData, const std::string &key,
                  const std::string &resourcePath="", bool cachePolicy=true,
-	             const std::vector<std::pair<std::uint32_t, std::uint32_t>>
-				     &colorReplacements = {}, FitzModifier fitzModifier = FitzModifier::None);
+	             const std::vector<std::pair<std::uint32_t, std::uint32_t>> &colorReplacements = {},
+                 FitzModifier fitzModifier = FitzModifier::None,
+                 ParserColorFormat colorFormat = ParserColorFormat::Rgb);
 
     /**
      *  @brief Returns default framerate of the Lottie resource.

--- a/src/lottie/lottieanimation.cpp
+++ b/src/lottie/lottieanimation.cpp
@@ -241,8 +241,9 @@ std::future<Surface> AnimationImpl::renderAsync(size_t    frameNo,
 std::unique_ptr<Animation> Animation::loadFromData(
     std::string jsonData, const std::string &key,
     const std::string &resourcePath, bool cachePolicy,
-    const std::vector<std::pair<std::uint32_t, std::uint32_t>>
-        &colorReplacements, FitzModifier fitzModifier)
+    const std::vector<std::pair<std::uint32_t, std::uint32_t>> &colorReplacements,
+    FitzModifier fitzModifier,
+    ParserColorFormat colorFormat)
 {
     if (jsonData.empty()) {
         vWarning << "jason data is empty";
@@ -252,7 +253,7 @@ std::unique_ptr<Animation> Animation::loadFromData(
     LottieLoader loader;
     if (loader.loadFromData(std::move(jsonData), key,
                             (resourcePath.empty() ? " " : resourcePath),
-                            cachePolicy, colorReplacements, fitzModifier)) {
+                            cachePolicy, colorReplacements, fitzModifier, colorFormat)) {
         auto animation = std::unique_ptr<Animation>(new Animation);
         animation->d->init(loader.model());
         return animation;

--- a/src/lottie/lottieloader.cpp
+++ b/src/lottie/lottieloader.cpp
@@ -143,8 +143,9 @@ bool LottieLoader::load(const std::string &path, bool cachePolicy)
 bool LottieLoader::loadFromData(
     std::string &&jsonData, const std::string &key,
     const std::string &resourcePath, bool cachePolicy,
-    const std::vector<std::pair<std::uint32_t, std::uint32_t>>
-        &colorReplacements, rlottie::FitzModifier fitzModifier)
+    const std::vector<std::pair<std::uint32_t, std::uint32_t>> &colorReplacements,
+    rlottie::FitzModifier fitzModifier,
+    rlottie::ParserColorFormat colorFormat)
 {
     if (cachePolicy) {
         mModel = LottieModelCache::instance().find(key);
@@ -152,7 +153,7 @@ bool LottieLoader::loadFromData(
     }
 
     LottieParser parser(const_cast<char *>(jsonData.c_str()),
-                        resourcePath.c_str(), colorReplacements, fitzModifier);
+                        resourcePath.c_str(), colorReplacements, fitzModifier, colorFormat);
     mModel = parser.model();
 
     if (!mModel) return false;

--- a/src/lottie/lottieloader.h
+++ b/src/lottie/lottieloader.h
@@ -33,8 +33,9 @@ public:
    bool load(const std::string &filePath, bool cachePolicy);
    bool loadFromData(std::string &&jsonData, const std::string &key,
                      const std::string &resourcePath, bool cachePolicy,
-                     const std::vector<std::pair<std::uint32_t, std::uint32_t>>
-                         &colorReplacements, rlottie::FitzModifier fitzModifier);
+                     const std::vector<std::pair<std::uint32_t, std::uint32_t>> &colorReplacements,
+                     rlottie::FitzModifier fitzModifier,
+                     rlottie::ParserColorFormat colorFormat);
    std::shared_ptr<LOTModel> model();
 private:  
    std::shared_ptr<LOTModel>    mModel;

--- a/src/lottie/lottieparser.h
+++ b/src/lottie/lottieparser.h
@@ -28,8 +28,9 @@ class LottieParser {
 public:
     ~LottieParser();
     LottieParser(char *str, const char *dir_path,
-                 const std::vector<std::pair<std::uint32_t, std::uint32_t>>
-                     &colorReplacements = {}, rlottie::FitzModifier fitzModifier = rlottie::FitzModifier::None);
+                 const std::vector<std::pair<std::uint32_t, std::uint32_t>> &colorReplacements = {},
+                 rlottie::FitzModifier fitzModifier = rlottie::FitzModifier::None,
+                 rlottie::ParserColorFormat colorFormat = rlottie::ParserColorFormat::Rgb);
     std::shared_ptr<LOTModel> model();
 private:
    std::unique_ptr<LottieParserImpl>  d;


### PR DESCRIPTION
Added `enum ParserColorFormat` to control color components order in `lottieparser.cpp`. 
It could be useful for Android projects where bitmap pixels in native code stored in BGRA format.